### PR TITLE
[Feat] 캘린더 렌더링 로직 구현

### DIFF
--- a/FE/src/components/Calendar/index.tsx
+++ b/FE/src/components/Calendar/index.tsx
@@ -8,15 +8,16 @@ interface CalendarProps {
   activeMonth: number;
 }
 
+// TODO: interface DateProps하나에서 extends해서 확장해서 써보기
 interface DateProps {
   year: number;
   month: number;
   date: number;
+  isAciveMonth: boolean;
 }
 
 interface RenderDateProps extends DateProps {
   id: Date;
-  isAciveMonth: boolean;
 }
 
 interface RenderDatesProps {
@@ -38,6 +39,7 @@ export default function Calendar({ activeYear, activeMonth }: CalendarProps) {
         ))}
       </S.WeekContainer>
       <S.WeekContainer>
+        {/* FIXME: 키 값 겹치는 에러 수정하기 */}
         {dates.map(({ id, date, isAciveMonth }) => (
           <S.DayItem isAciveMonth={isAciveMonth} key={id}>
             {date}
@@ -77,6 +79,7 @@ function renderCalendar({ activeYear, activeMonth }: CalendarProps): Array<Rende
   return prevMonthDates.concat(currentMonthDates, nextMonthDates);
 }
 
+// TODO: 6 (getDay()로 얻은 토요일 값): 매직넘버 수정하기
 function renderPrevMonthLastWeek(
   prevMonthLastDay: number,
   prevMonthLastDate: number,
@@ -112,23 +115,30 @@ function renderNextMonthFirstWeek(
   return [];
 }
 
-function renderDates({ length, year, month, addedDate }: RenderDatesProps): Array<RenderDateProps> {
+function renderDates({
+  length,
+  year,
+  month,
+  addedDate,
+  isAciveMonth,
+}: RenderDatesProps): Array<RenderDateProps> {
   // TODO: //  RenderDateProps[] 배열 타입 지정 고려해보기
   return Array.from({ length }, (v, i) =>
     renderDate({
       year,
       month,
       date: i + 1 + addedDate,
+      isAciveMonth,
     }),
   );
 }
 
-function renderDate({ year, month, date }: DateProps): RenderDateProps {
+function renderDate({ year, month, date, isAciveMonth }: DateProps): RenderDateProps {
   return {
     id: new Date(year, month, date),
     year,
     month,
     date,
-    isAciveMonth: false,
+    isAciveMonth,
   };
 }

--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -10,6 +10,7 @@ interface CalendarModalProps {
 }
 
 export default function CalendarModal({ isModalOpen, handleOpenModal }: CalendarModalProps) {
+  // TODO: date formater util로 분리하기
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth();
@@ -18,6 +19,7 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
   return (
     <WindowModal show={isModalOpen} handleOpenModal={handleOpenModal}>
       <div style={{ display: 'flex', gap: '12px' }}>
+        {/* TODO: activeMonth + magic number 수정하기 */}
         <Calendar activeMonth={activeMonth - 1} activeYear={activeYear} />
         <Calendar activeMonth={activeMonth} activeYear={activeYear} />
         <Calendar activeMonth={activeMonth + 1} activeYear={activeYear} />

--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import Calendar from '@/components/Calendar';
 
 import WindowModal from '../WindowModal';
@@ -8,10 +10,19 @@ interface CalendarModalProps {
 }
 
 export default function CalendarModal({ isModalOpen, handleOpenModal }: CalendarModalProps) {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const [activeYear, setActiveYear] = useState(year);
+  const [activeMonth, setActiveMonth] = useState(month);
   return (
     <WindowModal show={isModalOpen} handleOpenModal={handleOpenModal}>
-      <div>Calendar</div>
-      <Calendar />
+      <div style={{ display: 'flex', gap: '12px' }}>
+        <Calendar activeMonth={activeMonth - 1} activeYear={activeYear} />
+        <Calendar activeMonth={activeMonth} activeYear={activeYear} />
+        <Calendar activeMonth={activeMonth + 1} activeYear={activeYear} />
+        <Calendar activeMonth={activeMonth + 2} activeYear={activeYear} />
+      </div>
     </WindowModal>
   );
 }

--- a/FE/src/components/WindowModal/style.js
+++ b/FE/src/components/WindowModal/style.js
@@ -14,8 +14,8 @@ export const ModalWrapper = styled.div`
 export const ModalContainer = styled.div`
   margin-top: 200px;
   display: inline-block;
-  width: 440px;
-  height: 440px;
+  /* width: 440px;
+  height: 440px; */
   background: white;
   border: 1px solid black;
   z-index: 1012;

--- a/FE/src/constants/constants.js
+++ b/FE/src/constants/constants.js
@@ -13,4 +13,4 @@ export const months = [
   'December',
 ];
 
-export const daysOfWeek = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+export const daysOfWeek = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];


### PR DESCRIPTION
### About

캘린더 렌더링 로직 구현

### Description

`캘린더에 표시되는 날짜들`: 이전 달의 마지막 주 + 현재 달 + 다음 달의 첫 째주

### Result

![캘린더](https://user-images.githubusercontent.com/71386219/171135845-cc9528dc-58f0-4b1e-bcce-cd01a636d920.png)

### 더 해야하는 부분

- [ ] : 매직넘버 줄이기
- [ ] : 로직을 간단하게 줄여보기
- [ ] : key 값. 겹치는 오류 해결하기
- [ ] : styled-copmonent 관련 typescript 오류 해결하기

### Ref

#16 
