### PR TITLE
[Feat] 달력 무한 캐러셀 우측 구현

### DIFF
--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -25,7 +25,6 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
     activeMonth + 1,
     activeMonth + 2,
     activeMonth + 3,
-    activeMonth + 4,
   ]);
   const [nextCount, setNextCount] = useState(1);
   const [isSlide, setIsSlide] = useState(false);
@@ -36,8 +35,8 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
 
   const divide = months.length - 1;
   const currentMonthOrder = 1;
-  const lastMonthOrder = 4;
-  const increasedMonth = 3;
+  const lastMonthOrder = divide - 1;
+  const increasedMonth = divide - 2;
   const itemGap = 26;
 
   const handleClickNextCalendar = () => {

--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react';
+/* eslint-disable prettier/prettier */
+import { useEffect, useState } from 'react';
 
 import Calendar from '@/components/Calendar';
 
 import WindowModal from '../WindowModal';
+import * as S from './style';
 
 interface CalendarModalProps {
   isModalOpen: boolean;
@@ -16,15 +18,71 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
   const month = today.getMonth();
   const [activeYear, setActiveYear] = useState(year);
   const [activeMonth, setActiveMonth] = useState(month);
+  // TODO : 12월 넘어가면 1월부터 다시 시작하고 year은 1추가로 수정하기
+  const [months, setMonths] = useState([
+    activeMonth - 1,
+    activeMonth,
+    activeMonth + 1,
+    activeMonth + 2,
+    activeMonth + 3,
+    activeMonth + 4,
+  ]);
+  const [nextCount, setNextCount] = useState(1);
+  const [isSlide, setIsSlide] = useState(false);
+  const [transtion, setTransition] = useState('transform 1s linear 0s');
+
+  // TODO : handleClickNextCalendar를 참고하여 이전 달력 클릭 핸들러 구현하기
+  const handleClickPreviousCalendar = () => {};
+
+  const divide = months.length - 1;
+  const currentMonthOrder = 1;
+  const lastMonthOrder = 4;
+  const increasedMonth = 3;
+  const itemGap = 26;
+
+  const handleClickNextCalendar = () => {
+    setActiveMonth(activeMonth + 1);
+    const newOrder = (nextCount + 1) % divide;
+    const firstMonthOrder = newOrder + 1;
+    setNextCount(nextCount === lastMonthOrder ? firstMonthOrder : newOrder);
+  };
+
+  useEffect(() => {
+    if (nextCount === currentMonthOrder) {
+      setTransition('transform 1s linear 0s');
+      if (isSlide) {
+        // TODO : 12월 넘어가면 1월부터 다시 시작하고 year은 1추가로 수정하기
+        setMonths([...months.map(currentMonth => currentMonth + increasedMonth)]);
+        setTimeout(function () {
+          setNextCount((nextCount + 1) % divide);
+        }, 0);
+        setTransition('');
+      }
+      setIsSlide(false);
+    } else if (nextCount === lastMonthOrder) {
+      setIsSlide(true);
+    }
+  }, [nextCount, transtion, isSlide]);
+
   return (
     <WindowModal show={isModalOpen} handleOpenModal={handleOpenModal}>
-      <div style={{ display: 'flex', gap: '12px' }}>
-        {/* TODO: activeMonth + magic number 수정하기 */}
-        <Calendar activeMonth={activeMonth - 1} activeYear={activeYear} />
-        <Calendar activeMonth={activeMonth} activeYear={activeYear} />
-        <Calendar activeMonth={activeMonth + 1} activeYear={activeYear} />
-        <Calendar activeMonth={activeMonth + 2} activeYear={activeYear} />
-      </div>
+      <S.CalendarContainer>
+        {/* TODO: div태그 styled로 변경 */}
+        <div style={{ display: 'flex', gap: '12px' }}>
+          {/* TODO: activeMonth + magic number 수정하기 */}
+          <button type="button" onClick={handleClickPreviousCalendar}></button>
+          <div style={{ overflow: 'hidden' }}>
+            <S.ItemContainer nextCount={nextCount} transtion={transtion} divide={divide}>
+              {months.map(currentActiveMonth => (
+                <S.Item key={`activeMonth-${currentActiveMonth}`} itemGap={itemGap}>
+                  <Calendar activeMonth={currentActiveMonth} activeYear={activeYear} />
+                </S.Item>
+              ))}
+            </S.ItemContainer>
+          </div>
+          <button type="button" onClick={handleClickNextCalendar}></button>
+        </div>
+      </S.CalendarContainer>
     </WindowModal>
   );
 }

--- a/FE/src/components/CalendarModal/style.js
+++ b/FE/src/components/CalendarModal/style.js
@@ -1,0 +1,27 @@
+/* eslint-disable prettier/prettier */
+import styled from 'styled-components';
+
+export const CalendarContainer = styled.div`
+  width: 440px;
+  height: 440px;
+`;
+
+export const Wrapper = styled.div`
+  overflow: hidden;
+`;
+
+export const ItemContainer = styled.ul`
+  display: flex;
+  width: 100%;
+  padding: 0; // TODO : reset css 적용시 삭제하기
+  transition: ${({ transtion }) => transtion};
+  transform: ${({ nextCount, divide }) =>
+    nextCount === 0 ? `translateX(-50%)` : `translateX(${-50 * (nextCount % divide)}%)`};
+`;
+
+export const Item = styled.li`
+  flex-shrink: 0;
+  width: ${({ itemGap }) => `calc(50% - ${itemGap}px)`};
+  margin: 0 ${({ itemGap }) => itemGap / 2}px;
+  list-style: none; // TODO : reset css 적용시 삭제하기
+`;


### PR DESCRIPTION
### About

달력 무한 캐러셀 우측 구현

### Description
- [x] 달력 무한 캐러셀 우측 구현
- [ ] 달력 무한 캐러셀 좌측 구현
- [ ] 우측 버튼 클릭하는 경우 12월 지나면 1월부터 시작 및 년도 1증가

기존 설계대로 구현하는 것에 어려움이 있어서 무한 캐러셀을 이용하는 것으로 설계를 수정하였습니다.
우측 버튼 클릭시 달력 렌더링 까지 구현하였습니다.

### 기존 설계

![image](https://user-images.githubusercontent.com/58525009/171591216-0859dec6-7528-49b8-b772-8c3aa1bf8e0d.png)


### 수정한 설계 

![image](https://user-images.githubusercontent.com/58525009/171591048-b23732ea-5442-4d60-93f7-a38b0b4046c6.png)



첫 모달 킬때 months의 최초값이 다음 달로 보이고, 모달을 다시 누르는 경우 현재달이 아닌 마지막에 캐러셀로 조회한 달력이 나옵니다.

reset css 아직 적용 안하고 해봤는데 ul에 기본으로 padding이 들어가서 이것때문에 엄청 헤맸습니다.

### Result

https://user-images.githubusercontent.com/58525009/171565185-b461a886-df43-4dbb-9beb-1fca40e6d326.mp4

### Ref

#22 
