### PR TITLE
[Refactor] 달력 컴포넌트에서 styled 분리

### DIFF
--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import { useEffect, useState } from 'react';
 
 import Calendar from '@/components/Calendar';
@@ -66,21 +65,22 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
   return (
     <WindowModal show={isModalOpen} handleOpenModal={handleOpenModal}>
       <S.CalendarContainer>
-        {/* TODO: div태그 styled로 변경 */}
-        <div style={{ display: 'flex', gap: '12px' }}>
-          {/* TODO: activeMonth + magic number 수정하기 */}
-          <button type="button" onClick={handleClickPreviousCalendar}></button>
-          <div style={{ overflow: 'hidden' }}>
-            <S.ItemContainer nextCount={nextCount} transtion={transtion} divide={divide}>
-              {months.map(currentActiveMonth => (
-                <S.Item key={`activeMonth-${currentActiveMonth}`} itemGap={itemGap}>
-                  <Calendar activeMonth={currentActiveMonth} activeYear={activeYear} />
-                </S.Item>
-              ))}
-            </S.ItemContainer>
-          </div>
-          <button type="button" onClick={handleClickNextCalendar}></button>
-        </div>
+        {/* TODO: activeMonth + magic number 수정하기 */}
+        <button type="button" onClick={handleClickPreviousCalendar}>
+          이전달
+        </button>
+        <S.Wrapper>
+          <S.ItemContainer nextCount={nextCount} transtion={transtion} divide={divide}>
+            {months.map(currentActiveMonth => (
+              <S.Item key={`activeMonth-${currentActiveMonth}`} itemGap={itemGap}>
+                <Calendar activeMonth={currentActiveMonth} activeYear={activeYear} />
+              </S.Item>
+            ))}
+          </S.ItemContainer>
+        </S.Wrapper>
+        <button type="button" onClick={handleClickNextCalendar}>
+          다음달
+        </button>
       </S.CalendarContainer>
     </WindowModal>
   );

--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -29,14 +29,13 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
   const [isSlide, setIsSlide] = useState(false);
   const [transtion, setTransition] = useState('transform 1s linear 0s');
 
-  // TODO : handleClickNextCalendar를 참고하여 이전 달력 클릭 핸들러 구현하기
-  const handleClickPreviousCalendar = () => {};
-
   const divide = months.length - 1;
   const currentMonthOrder = 1;
   const lastMonthOrder = divide - 1;
   const increasedMonth = divide - 2;
   const itemGap = 26;
+
+  const handleClickPreviousCalendar = () => {};
 
   const handleClickNextCalendar = () => {
     setActiveMonth(activeMonth + 1);
@@ -46,6 +45,7 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
   };
 
   useEffect(() => {
+    // FIXME: useEffect 내부 로직 함수로 분리
     if (nextCount === currentMonthOrder) {
       setTransition('transform 1s linear 0s');
       if (isSlide) {
@@ -70,7 +70,7 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
           이전달
         </button>
         <S.Wrapper>
-          <S.ItemContainer nextCount={nextCount} transtion={transtion} divide={divide}>
+          <S.ItemContainer nextCount={nextCount} transtion={transtion}>
             {months.map(currentActiveMonth => (
               <S.Item key={`activeMonth-${currentActiveMonth}`} itemGap={itemGap}>
                 <Calendar activeMonth={currentActiveMonth} activeYear={activeYear} />

--- a/FE/src/components/CalendarModal/index.tsx
+++ b/FE/src/components/CalendarModal/index.tsx
@@ -26,8 +26,8 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
     activeMonth + 3,
   ]);
   const [nextCount, setNextCount] = useState(1);
-  const [isSlide, setIsSlide] = useState(false);
-  const [transtion, setTransition] = useState('transform 1s linear 0s');
+  const [isCombackSlide, setIsCombackSlide] = useState(false);
+  const [transition, setTransition] = useState('transform 1s linear 0s');
 
   const divide = months.length - 1;
   const currentMonthOrder = 1;
@@ -48,7 +48,7 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
     // FIXME: useEffect 내부 로직 함수로 분리
     if (nextCount === currentMonthOrder) {
       setTransition('transform 1s linear 0s');
-      if (isSlide) {
+      if (isCombackSlide) {
         // TODO : 12월 넘어가면 1월부터 다시 시작하고 year은 1추가로 수정하기
         setMonths([...months.map(currentMonth => currentMonth + increasedMonth)]);
         setTimeout(function () {
@@ -56,11 +56,11 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
         }, 0);
         setTransition('');
       }
-      setIsSlide(false);
+      setIsCombackSlide(false);
     } else if (nextCount === lastMonthOrder) {
-      setIsSlide(true);
+      setIsCombackSlide(true);
     }
-  }, [nextCount, transtion, isSlide]);
+  }, [nextCount, transition, isCombackSlide]);
 
   return (
     <WindowModal show={isModalOpen} handleOpenModal={handleOpenModal}>
@@ -70,7 +70,7 @@ export default function CalendarModal({ isModalOpen, handleOpenModal }: Calendar
           이전달
         </button>
         <S.Wrapper>
-          <S.ItemContainer nextCount={nextCount} transtion={transtion}>
+          <S.ItemContainer nextCount={nextCount} transition={transition}>
             {months.map(currentActiveMonth => (
               <S.Item key={`activeMonth-${currentActiveMonth}`} itemGap={itemGap}>
                 <Calendar activeMonth={currentActiveMonth} activeYear={activeYear} />

--- a/FE/src/components/CalendarModal/style.js
+++ b/FE/src/components/CalendarModal/style.js
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 export const CalendarContainer = styled.div`
   width: 440px;
   height: 440px;
+  display: 'flex';
+  gap: '12px';
 `;
 
 export const Wrapper = styled.div`

--- a/FE/src/components/CalendarModal/style.js
+++ b/FE/src/components/CalendarModal/style.js
@@ -16,7 +16,7 @@ export const ItemContainer = styled.ul`
   display: flex;
   width: 100%;
   padding: 0; // TODO : reset css 적용시 삭제하기
-  transition: ${({ transtion }) => transtion};
+  transition: ${({ transition }) => transition};
   transform: ${({ nextCount }) =>
     nextCount === 0 ? `translateX(-50%)` : `translateX(${-50 * nextCount}%)`};
 `;

--- a/FE/src/components/CalendarModal/style.js
+++ b/FE/src/components/CalendarModal/style.js
@@ -17,8 +17,8 @@ export const ItemContainer = styled.ul`
   width: 100%;
   padding: 0; // TODO : reset css 적용시 삭제하기
   transition: ${({ transtion }) => transtion};
-  transform: ${({ nextCount, divide }) =>
-    nextCount === 0 ? `translateX(-50%)` : `translateX(${-50 * (nextCount % divide)}%)`};
+  transform: ${({ nextCount }) =>
+    nextCount === 0 ? `translateX(-50%)` : `translateX(${-50 * nextCount}%)`};
 `;
 
 export const Item = styled.li`


### PR DESCRIPTION
### About

달력 컴포넌트에서 styled 분리

### 궁금한 점

- 다른 사람코드를 이어서 작업하는게 생각만큼 쉽지 않네요 ㅜㅜ
- 아래 코드에서 궁금한 점을 주석으로 남겨뒀어요!
- 캐러셀은 좌우버튼을 클릭할 때마다 얼마나 화면을 이동할지 결정해야한다고 했을 때, `상태는 화면을 얼마나 이동할지+ 현재 active된 달`, `동작은 좌우버튼 클릭`이라고 생각해요.
- 저는 useEffect라는 함수는 dependency에 있는 상태가 바뀜에 따라 실행되어야하는 함수가 있어야한다고 생각해요. 현재 코드에서는 useEffect 내부에 특정 상태에 따라 실행하는 함수(중첩된 if문, if문 조건 이해가 어려운 문제)가 있어서 이해하기 어렵다고 느껴졌어요. 예를 들어, 현재 useEffect안의 `if(Slide){}` 에서 다음 달을 렌더링하는 로직이 들어있는데, 이전 달을 렌더링하는 로직을 어디에 추가해야할지 감이 잡히지 않았습니다. ㅜㅜ

```jsx
useEffect(() => {
    if (nextCount === currentMonthOrder) { // 어떤 상황일까요? 아래 elseif문도 있는데 else일 때는 아무 것도 안하나요?
      setTransition('transform 1s linear 0s');
      if (isSlide) {
        setMonths([...months.map(currentMonth => currentMonth + increasedMonth)]); 
// 함수로 분리해야할 것 같아요. 어떤 동작을 하는지 setter의 callback을 해석하는데 시간이 걸리네요. 
        setTimeout(function () {
          setNextCount((nextCount + 1) % divide);
        }, 0);
        setTransition('');
      }
      setIsSlide(false);
 // isSide가 true일 때만 특정 동작을 하는거 같은데 특정 동작이 달을 추가하는 작업인가요? 추가하는 작업만 보이는데 달을 빼는 작업은 어디에 추가해야할까요? 
    } else if (nextCount === lastMonthOrder) {
      setIsSlide(true);
    }
  }, [nextCount, transtion, isSlide]);
```



### Ref

#25 