### PR TITLE
[Feat] 가격 범위 차트에 양방향 슬라이더 구현

### DIFF
--- a/FE/src/components/Chart/index.tsx
+++ b/FE/src/components/Chart/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from 'react';
 
+import { PRIMARY_COLOR, SECONDARY_COLOR } from '@/style';
+
 export interface ChartProps {
   xDataset: number[];
   yDataset: number[];
@@ -59,7 +61,7 @@ export default function Chart({
     setPositions(context, xDataset, yDataset, maximumX, maximumY, width, height);
 
     context.stroke();
-    fillContext(context, height, 0, width, 'wheat');
+    fillContext(context, height, 0, width, SECONDARY_COLOR);
   };
 
   const drawAciveChart = (leftX: number, rigthX: number) => {
@@ -80,7 +82,7 @@ export default function Chart({
     setPositions(context, newXDataset, newYDataset, maximumX, maximumY, width, height);
     context.stroke();
 
-    fillContext(context, height, revisedLeftX, revisedRigthX, 'tomato');
+    fillContext(context, height, revisedLeftX, revisedRigthX, PRIMARY_COLOR);
   };
 
   useEffect(() => {

--- a/FE/src/components/PriceChart/index.tsx
+++ b/FE/src/components/PriceChart/index.tsx
@@ -57,6 +57,9 @@ export default function PriceChart({ chartInfo, axis, xStep, yStep }: PriceChart
   const revisedLeftX = calculateXRatio(leftThumbX, maximumX, CANVAS_WIDTH);
   const revisedLeftY = calculateYRatio(leftY, maximumY, CANVAS_HEIGHT);
 
+  const moveLeftThumbX = (leftThumbX / maximumX) * 100;
+  const moveRightThumbX = 100 - (rightThumbX / maximumX) * 100;
+
   return (
     <S.CanvasContainer>
       <Chart
@@ -70,7 +73,7 @@ export default function PriceChart({ chartInfo, axis, xStep, yStep }: PriceChart
         revisedValues={{ revisedRigthX, revisedLeftX, revisedLeftY }}
       />
       <label>최소</label>
-      <input
+      <S.SliderController
         type="range"
         value={leftThumbX}
         step={xStep}
@@ -80,7 +83,7 @@ export default function PriceChart({ chartInfo, axis, xStep, yStep }: PriceChart
       />
       <br />
       <label>최대</label>
-      <input
+      <S.SliderController
         type="range"
         value={rightThumbX}
         step={xStep}
@@ -88,6 +91,12 @@ export default function PriceChart({ chartInfo, axis, xStep, yStep }: PriceChart
         max={maximumX}
         onChange={handleMaxPriceChange}
       />
+      <S.VirtualSlider>
+        <S.Track></S.Track>
+        <S.Range moveLeftThumbX={moveLeftThumbX} moveRightThumbX={moveRightThumbX}></S.Range>
+        <S.LeftThumb moveLeftThumbX={moveLeftThumbX}></S.LeftThumb>
+        <S.RightThumb moveRightThumbX={moveRightThumbX}></S.RightThumb>
+      </S.VirtualSlider>
     </S.CanvasContainer>
   );
 }

--- a/FE/src/components/PriceChart/style.js
+++ b/FE/src/components/PriceChart/style.js
@@ -1,7 +1,79 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
+import { PRIMARY_COLOR, SECONDARY_COLOR } from '@/style';
+
+import { CANVAS_WIDTH } from './constants';
 import containerSize from './mixins';
+
+const THUMB_SIZE = '16px';
 
 export const CanvasContainer = styled.div`
   ${containerSize}
+`;
+
+export const SliderController = styled.input`
+  width: ${CANVAS_WIDTH}px;
+  position: absolute;
+  pointer-events: none; // 범위 range 이벤트 중지
+  z-index: 3;
+  appearance: none;
+  opacity: 0;
+  ::-webkit-slider-thumb {
+    pointer-events: all; // thumb 이벤트 감지
+    appearance: none;
+    cursor: pointer;
+    width: ${THUMB_SIZE};
+    height: 4rem;
+  }
+`;
+
+export const VirtualSlider = styled.div`
+  position: relative;
+  z-index: 1;
+  left: 30px;
+  height: 10px;
+`;
+
+export const Track = styled.div`
+  position: absolute;
+  z-index: 1;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  border-radius: 5px;
+  background-color: ${SECONDARY_COLOR};
+`;
+
+export const Range = styled.div`
+  position: absolute;
+  z-index: 2;
+  left: ${({ moveLeftThumbX }) => moveLeftThumbX}%;
+  right: ${({ moveRightThumbX }) => moveRightThumbX}%;
+  top: 0;
+  bottom: 0;
+  border-radius: 5px;
+  background-color: ${PRIMARY_COLOR};
+`;
+
+const thumb = css`
+  position: absolute;
+  z-index: 3;
+  width: ${THUMB_SIZE};
+  height: 16px;
+  background-color: ${PRIMARY_COLOR};
+  border-radius: 50%;
+  top: 7px;
+`;
+
+export const LeftThumb = styled.div`
+  ${thumb}
+  left: calc(${({ moveLeftThumbX }) => moveLeftThumbX}% + ${THUMB_SIZE});
+  transform: translate(-100%, -60%);
+`;
+
+export const RightThumb = styled.div`
+  ${thumb}
+  right: calc(${({ moveRightThumbX }) => moveRightThumbX}% + ${THUMB_SIZE});
+  transform: translate(100%, -60%);
 `;

--- a/FE/src/style/index.js
+++ b/FE/src/style/index.js
@@ -1,0 +1,2 @@
+export const PRIMARY_COLOR = 'tomato';
+export const SECONDARY_COLOR = 'wheat';


### PR DESCRIPTION
## 기능 요청사항

양방향 슬라이더

## 요청 세부사항

- [x] : 양방향 슬라이더
- [ ] : 최대 최소 부분의 원본 input이 안보이지만 움직이는 event가 아직 동작, 이 부분 의도적으로 중지했지만 아직도 동작하여 해결 필요
- [ ] : x축, y축 라벨 및 헤더, 단위 표시, 평균값표시

### Result

https://user-images.githubusercontent.com/58525009/172348674-17afeccd-9f3d-45be-bc45-bde53746a39c.mp4

ex) 실행, 테스트 결과 또는 사진 첨부

#32 