### PR TITLE
Feat: 캘린더 Date Picker 체크인, 체크아웃 날짜 설정

### DIFF
--- a/FE/src/components/CalendarCourousel/Calendar/index.tsx
+++ b/FE/src/components/CalendarCourousel/Calendar/index.tsx
@@ -1,10 +1,17 @@
+import { SelectedDateType } from '@/components/CalendarCourousel';
 import { months, daysOfWeek, saturdayNumber } from '@/constants/constants';
 
 import * as S from './style';
 
+interface CalendarInfoType {
+  activeYear: number;
+  activeMonth: number;
+}
+
 interface CalendarProps {
   activeYear: number;
   activeMonth: number;
+  handleClickDay: (selectedDate: SelectedDateType) => void;
 }
 
 interface DateProps {
@@ -26,7 +33,7 @@ interface DatesProps {
   addedDate: number;
 }
 
-export default function Calendar({ activeYear, activeMonth }: CalendarProps) {
+export default function Calendar({ activeYear, activeMonth, handleClickDay }: CalendarProps) {
   const dates = getCalendarInfo({ activeYear, activeMonth });
   return (
     <S.Container>
@@ -38,14 +45,19 @@ export default function Calendar({ activeYear, activeMonth }: CalendarProps) {
       </S.WeekContainer>
       <S.WeekContainer>
         {dates.map(({ id, date }) => (
-          <S.DayItem key={id}>{date}</S.DayItem>
+          <S.DayItem
+            key={id}
+            onClick={() => handleClickDay({ year: activeYear, month: activeMonth, date })}
+          >
+            {date}
+          </S.DayItem>
         ))}
       </S.WeekContainer>
     </S.Container>
   );
 }
 
-const getCalendarInfo = ({ activeYear, activeMonth }: CalendarProps): CalendarDateProps[] => {
+const getCalendarInfo = ({ activeYear, activeMonth }: CalendarInfoType): CalendarDateProps[] => {
   const prevMonthLastFullDate = new Date(activeYear, activeMonth, 0);
   const prevMonthLastDay = prevMonthLastFullDate.getDay();
   const prevMonthLastDate = prevMonthLastFullDate.getDate();


### PR DESCRIPTION
### About

캘린더 Date Picker 체크인, 체크아웃 날짜 설정

### Description

- [x] : 사용자가 처음 날짜를 클릭하면 체크인 일자로 반영한다.  -> 클릭하지않아도 기본값으로 현재 날짜와 다음날짜로 선택된다.
- [x] : 이미 입력한 체크인 일자보다 앞선 일자를 입력한 경우 나중에 입력한 값을 체크인 일자로 반영한다. 
- [x] : 이미 입력한 체크인 일자보다 늦은 일자를 클릭할 경우, 나중에 입력한 값을 체크아웃 일자로 반영한다. 
- [x] : 체크인, 체크아웃 일자를 설정하고 이후에 클릭한 날짜가 체크인, 체크아웃 범위일때 체크아웃이 갱신된다. 
- [x] : 체크인, 체크아웃 리셋 버튼을 누르면 날짜가 리셋된다. 

처음 렌더링시 디폴트 값으로 현재 날짜가 체크인, 내일이 체크아웃으로 설정되게 해봤습니다.

처음에 체크인, 체크아웃 상태를 하나의 객체상태 내부에 중첩으로 두었다가 중첩일때 상태가 제대로 변경되지 않아서 헤맸습니다. 이 부분 중첩으로 했을때 어떻게 잘 반영되게 할 수 있을지 다시 정리해보려고 합니다. 현재는 중첩구조로 하지 않았습니다.

처음 짰을때 로직의 코드가 많았는데 보기 너무 복잡해서 정리하고 보니 생각보다 로직의 코드가 적네요

### Result

https://user-images.githubusercontent.com/58525009/172524550-5cf614cc-af24-4cf1-b24d-d40cc2120bf1.mp4



### Ref

#37 
